### PR TITLE
build: correct header file location to support esp-idf v5.0

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -6,7 +6,13 @@
 #error "Error, ESP_PLATFORM required"
 #endif
 
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include <miniz.h> /* TINFL_LZ_DICT_SIZE */
+#else
 #include <esp32/rom/miniz.h> /* TINFL_LZ_DICT_SIZE */
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
Avoid deprecated header file path in esp-idf 5.0+  
(Have to retain prior path in <5.0 as file not present in new location)